### PR TITLE
Update LiberTEM dependency to 0.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
   - pip
 
 install:
-  - pip install tox
+  - pip install -U tox 'virtualenv>19'
 
 script:
   - tox
@@ -46,7 +46,7 @@ jobs:
       python: 3.7
       dist: xenial
       install:
-        - pip install tox
+        - pip install -U tox 'virtualenv>19'
         - sudo apt-get install -y pandoc
 
     - stage: packaging

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,3 +1,5 @@
+.. _`examples`:
+
 Examples
 ========
 

--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,8 @@ setup(
     ],
     extras_require={
         'pyfftw': 'pyfftw',
-        'common': ['libertem>=0.4.0.dev0', 'scikit-image'],
-        'udf': ['libertem>=0.4.0.dev0', 'scikit-image', 'matplotlib'],
+        'common': ['libertem>=0.4.0,<1', 'scikit-image'],
+        'udf': ['libertem>=0.4.0,<1', 'scikit-image', 'matplotlib'],
     },
     package_dir={"": "src"},
     # FIXME find_namespace_packages doesn't seem to be supported in Python 3.6

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,3 @@
 pytest>=5,<6
 pytest-cov
-git+https://github.com/LiberTEM/LiberTEM.git#egg=libertem
 scipy


### PR DESCRIPTION
Install libertem 0.4.0 from pypi, no longer test with libertem master via git.

As a note, later it may be a good idea to _additionally_ test against LiberTEM master, but that should also be triggered by the CI pipeline from LiberTEM (can easily be done once we are using Azure Pipelines).

Do you think this needs a changelog entry?

## Contributor Checklist:

* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM-blobfinder/tree/master/docs/source/changelog) for my contribution