### PR TITLE
Allow specifying per-frame coordinate offsets

### DIFF
--- a/docs/source/changelog/features/zeroshift.rst
+++ b/docs/source/changelog/features/zeroshift.rst
@@ -1,0 +1,7 @@
+[Feature] Allow specifying per-frame origin shift
+=================================================
+
+* Introduce the :code:`zero_shift` parameter to :class:`libertem_blobfinder.udf.correlation.CorrelationUDF`,
+  :meth:`libertem_blobfinder.udf.correlation.run_fastcorrelation` and
+  :meth:`libertem_blobfinder.udf.refinement.run_refine` to specify a per-frame shift of the zero order position.
+  This allows processing data with strong descan error. (:pr:`23`)

--- a/src/libertem_blobfinder/udf/correlation.py
+++ b/src/libertem_blobfinder/udf/correlation.py
@@ -103,7 +103,7 @@ class FastCorrelationUDF(CorrelationUDF):
             Numpy array of (y, x) coordinates with peak positions in px to correlate
         match_pattern : MatchPattern
             Instance of :class:`~libertem_blobfinder.MatchPattern`
-        zero_shift : Union[AUXBufferWrapper, numpy.ndarray], optional
+        zero_shift : Union[AUXBufferWrapper, numpy.ndarray, None], optional
             Zero shift, for example descan error. Can be :code:`None`, :code:`numpy.array((y, x))`
             or AUX data with :code:`(y, x)` for each frame.
         '''
@@ -166,7 +166,7 @@ class FullFrameCorrelationUDF(CorrelationUDF):
             Numpy array of (y, x) coordinates with peak positions in px to correlate
         match_pattern : MatchPattern
             Instance of :class:`~libertem_blobfinder.MatchPattern`
-        zero_shift : Union[AUXBufferWrapper, numpy.ndarray], optional
+        zero_shift : Union[AUXBufferWrapper, numpy.ndarray, None], optional
             Zero shift, for example descan error. Can be :code:`None`, :code:`numpy.array((y, x))`
             or AUX data with :code:`(y, x)` for each frame.
         '''
@@ -241,6 +241,8 @@ class SparseCorrelationUDF(CorrelationUDF):
         super().__init__(
             peaks=peaks, match_pattern=match_pattern, steps=steps, *args, **kwargs
         )
+        if self.params.zero_shift is not None:
+            raise ValueError("Parameter zero_shift not supported for SparseCorrelationUDF")
 
     def get_result_buffers(self):
         """
@@ -340,6 +342,9 @@ def run_fastcorrelation(
     peaks : numpy.ndarray
         List of peaks with (y, x) coordinates
     match_pattern : libertem_blobfinder.patterns.MatchPattern
+    zero_shift : Union[AUXBufferWrapper, numpy.ndarray, None], optional
+        Zero shift, for example descan error. Can be :code:`None`, :code:`numpy.array((y, x))`
+        or AUX data with :code:`(y, x)` for each frame.
     roi : numpy.ndarray, optional
         Boolean mask of the navigation dimension to select region of interest (ROI)
     progress : bool, optional

--- a/src/libertem_blobfinder/udf/correlation.py
+++ b/src/libertem_blobfinder/udf/correlation.py
@@ -331,7 +331,8 @@ class SparseCorrelationUDF(CorrelationUDF):
 
 
 def run_fastcorrelation(
-        ctx, dataset, peaks, match_pattern: MatchPattern, zero_shift=None, roi=None, progress=False):
+        ctx, dataset, peaks, match_pattern: MatchPattern, zero_shift=None, roi=None,
+        progress=False):
     """
     Wrapper function to construct and run a :class:`FastCorrelationUDF`
 

--- a/src/libertem_blobfinder/udf/correlation.py
+++ b/src/libertem_blobfinder/udf/correlation.py
@@ -13,7 +13,7 @@ from libertem_blobfinder.common.correlation import get_peaks
 
 class CorrelationUDF(UDF):
     '''
-    Abstract base class for peak correlation implementations
+    Base class for peak correlation implementations
     '''
     def __init__(self, peaks, zero_shift=None, *args, **kwargs):
         '''
@@ -22,6 +22,9 @@ class CorrelationUDF(UDF):
 
         peaks : numpy.ndarray
             Numpy array of (y, x) coordinates with peak positions in px to correlate
+        zero_shift : Union[AUXBufferWrapper, numpy.ndarray, None], optional
+            Zero shift, for example descan error. Can be :code:`None`, :code:`numpy.array((y, x))`
+            or AUX data with :code:`(y, x)` for each frame.
         '''
         super().__init__(peaks=np.round(peaks).astype(int), zero_shift=zero_shift, *args, **kwargs)
 

--- a/src/libertem_blobfinder/udf/refinement.py
+++ b/src/libertem_blobfinder/udf/refinement.py
@@ -106,7 +106,7 @@ class FastmatchMixin(RefinementMixin):
                 refineds=r.refineds[index],
                 peak_values=r.peak_values[index],
                 peak_elevations=r.peak_elevations[index],
-                zero=p.start_zero,
+                zero=p.start_zero + self.get_zero_shift(index),
                 a=p.start_a,
                 b=p.start_b,
             )
@@ -149,7 +149,8 @@ class AffineMixin(RefinementMixin):
 
 def run_refine(
         ctx, dataset, zero, a, b, match_pattern: MatchPattern, matcher: grm.Matcher,
-        correlation='fast', match='fast', indices=None, steps=5, roi=None, progress=False):
+        correlation='fast', match='fast', indices=None, steps=5, zero_shift=None, roi=None,
+        progress=False):
     '''
     Wrapper function to refine the given lattice for each frame by calculating
     approximate peak positions and refining them for each frame using a
@@ -195,8 +196,13 @@ def run_refine(
         Only for correlation == 'sparse': Correlation steps. See
         :meth:`~SparseCorelationUDF.__init__` for
         details.
+    zero_shift : Union[AUXBufferWrapper, numpy.ndarray], optional
+        Zero shift, for example descan error. Can be :code:`None`, :code:`numpy.array((y, x))`
+        or AUX data with :code:`(y, x)` for each frame.
     roi : numpy.ndarray, optional
         ROI for :meth:`~libertem.api.Context.run_udf`
+    progress : bool, optional
+        Show progress bar. Default :code:`False`
 
     Returns
     -------
@@ -268,7 +274,8 @@ def run_refine(
         start_b=b,
         match_pattern=match_pattern,
         matcher=matcher,
-        steps=steps
+        steps=steps,
+        zero_shift=zero_shift,
     )
 
     result = ctx.run_udf(

--- a/src/libertem_blobfinder/udf/refinement.py
+++ b/src/libertem_blobfinder/udf/refinement.py
@@ -196,9 +196,10 @@ def run_refine(
         Only for correlation == 'sparse': Correlation steps. See
         :meth:`~SparseCorelationUDF.__init__` for
         details.
-    zero_shift : Union[AUXBufferWrapper, numpy.ndarray], optional
+    zero_shift : Union[AUXBufferWrapper, numpy.ndarray, None], optional
         Zero shift, for example descan error. Can be :code:`None`, :code:`numpy.array((y, x))`
-        or AUX data with :code:`(y, x)` for each frame.
+        or AUX data with :code:`(y, x)` for each frame. Only supported for correlation methods
+        :code:`fast` and `fullframe`.
     roi : numpy.ndarray, optional
         ROI for :meth:`~libertem.api.Context.run_udf`
     progress : bool, optional

--- a/src/libertem_blobfinder/udf/utils.py
+++ b/src/libertem_blobfinder/udf/utils.py
@@ -12,13 +12,18 @@ def visualize_frame(ctx, ds, result, indices, r, y, x, axes, colors=None, stretc
     get_sample_frame = ctx.create_pick_analysis(dataset=ds, y=y, x=x)
     sample_frame = ctx.run(get_sample_frame)
 
+    if y is None:
+        select = (x, )
+    else:
+        select = (y, x)
+
     d = sample_frame[0].raw_data.astype(np.float32)
 
     pcm = axes.imshow(np.log(d - np.min(d) + 1))
 
-    refined = result['refineds'].data[y, x]
-    elevations = result['peak_elevations'].data[y, x]
-    selector = result['selector'].data[y, x]
+    refined = result['refineds'].data[select]
+    elevations = result['peak_elevations'].data[select]
+    selector = result['selector'].data[select]
 
     max_elevation = np.max(elevations)
 
@@ -26,9 +31,9 @@ def visualize_frame(ctx, ds, result, indices, r, y, x, axes, colors=None, stretc
     # individual peak positions.
     # A difference between best fit and individual peaks highlights outliers.
     calculated = grm.calc_coords(
-        zero=result['zero'].data[y, x],
-        a=result['a'].data[y, x],
-        b=result['b'].data[y, x],
+        zero=result['zero'].data[select],
+        a=result['a'].data[select],
+        b=result['b'].data[select],
         indices=indices
     )
 
@@ -39,9 +44,9 @@ def visualize_frame(ctx, ds, result, indices, r, y, x, axes, colors=None, stretc
         normalized_elevations=elevations/max_elevation,
         calculated=calculated,
         selector=selector,
-        zero=result['zero'].data[y, x],
-        a=result['a'].data[y, x],
-        b=result['b'].data[y, x],
+        zero=result['zero'].data[select],
+        a=result['a'].data[select],
+        b=result['b'].data[select],
         colors=colors,
         stretch=stretch,
     )

--- a/tests/test_udf.py
+++ b/tests/test_udf.py
@@ -425,7 +425,10 @@ def test_correlation_method_fullframe(lt_ctx, cls, dtype, kwargs):
         assert np.allclose(res['refineds'].data[0], peaks, atol=0.5)
 
 
-def test_visualize_smoke(lt_ctx):
+@pytest.mark.parametrize(
+    "navshape", ((1, 1), (1, ))
+)
+def test_visualize_smoke(navshape, lt_ctx):
     shape = np.array([128, 128])
     zero = shape / 2 + np.random.uniform(-1, 1, size=2)
     a = np.array([27.17, 0.]) + np.random.uniform(-1, 1, size=2)
@@ -437,7 +440,7 @@ def test_visualize_smoke(lt_ctx):
 
     data, indices, peaks = cbed_frame(*shape, zero, a, b, indices, radius)
 
-    data = data.reshape((1, 1, *shape))
+    data = data.reshape((*navshape, *shape))
 
     dataset = MemoryDataSet(data=data, tileshape=(1, *shape),
                             num_partitions=1, sig_dims=2)
@@ -460,9 +463,15 @@ def test_visualize_smoke(lt_ctx):
     )
 
     fig, axes = plt.subplots()
+    if len(navshape) == 1:
+        y = None
+    elif len(navshape) == 2:
+        y = 0
+    else:
+        raise ValueError(f"Nav shape too long, supported are 1D and 2D: {navshape}")
     udf.utils.visualize_frame(
         ctx=lt_ctx, ds=dataset, result=res, indices=real_indices,
-        r=radius, y=0, x=0, axes=axes
+        r=radius, y=y, x=0, axes=axes
     )
     # plt.show()
 


### PR DESCRIPTION
This helps to cope with a very large descan error and can improve fitting performance in a second pass if the first pass missed peaks.

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM-blobfinder/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM-blobfinder/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
