### PR TITLE
Run Python 3.8 tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,8 @@ jobs:
         - ulimit -n 4096
         - eval "$(pyenv init -)"
         - pyenv install -l
-        - pyenv install --skip-existing 3.8.5
-        - pyenv global 3.8.5
+        - pyenv install --skip-existing 3.8.0
+        - pyenv global 3.8.0
         - pyenv rehash
         - python --version
         - python3 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,8 @@ jobs:
         - ulimit -n 4096
         - eval "$(pyenv init -)"
         - pyenv install -l
-        - pyenv install --skip-existing 3.8.6
-        - pyenv global 3.8.6
+        - pyenv install --skip-existing 3.8.5
+        - pyenv global 3.8.5
         - pyenv rehash
         - python --version
         - python3 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ jobs:
         - ulimit -n 4096
         - eval "$(pyenv init -)"
         - pyenv install -l
-        - pyenv install --skip-existing 3.6.12
-        - pyenv global 3.6.12
+        - pyenv install --skip-existing 3.6.9
+        - pyenv global 3.6.9
         - pyenv rehash
         - python --version
         - python3 --version
@@ -52,8 +52,8 @@ jobs:
         - ulimit -n 4096
         - eval "$(pyenv init -)"
         - pyenv install -l
-        - pyenv install --skip-existing 3.7.9
-        - pyenv global 3.7.9
+        - pyenv install --skip-existing 3.7.5
+        - pyenv global 3.7.5
         - pyenv rehash
         - python --version
         - python3 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ jobs:
     - stage: test
       env: TOXENV=py37
       python: 3.7
+    - stage: test
+      env: TOXENV=py38
+      python: 3.8
 
     # OSX tests:
     - stage: test
@@ -33,8 +36,8 @@ jobs:
         - ulimit -n 4096
         - eval "$(pyenv init -)"
         - pyenv install -l
-        - pyenv install --skip-existing 3.6.9
-        - pyenv global 3.6.9
+        - pyenv install --skip-existing 3.6.12
+        - pyenv global 3.6.12
         - pyenv rehash
         - python --version
         - python3 --version
@@ -49,8 +52,24 @@ jobs:
         - ulimit -n 4096
         - eval "$(pyenv init -)"
         - pyenv install -l
-        - pyenv install --skip-existing 3.7.5
-        - pyenv global 3.7.5
+        - pyenv install --skip-existing 3.7.9
+        - pyenv global 3.7.9
+        - pyenv rehash
+        - python --version
+        - python3 --version
+        - pip3 --version
+        - pip --version
+      language: shell
+    - stage: test
+      os: osx
+      env: TOXENV=py38
+      before_install:
+        - ulimit -n
+        - ulimit -n 4096
+        - eval "$(pyenv init -)"
+        - pyenv install -l
+        - pyenv install --skip-existing 3.8.6
+        - pyenv global 3.8.6
         - pyenv rehash
         - python --version
         - python3 --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,11 @@ environment:
       PYTHON_ARCH: "64"
       TOXENV: "py37"
 
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8"
+      PYTHON_ARCH: "64"
+      TOXENV: "py38"
+
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
 


### PR DESCRIPTION
<strike>...and update OS X Python versions to latest releases</strike> ... seems that the supported versions on OS X are ancient.

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM-blobfinder/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM-blobfinder/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated test cases
