### PR TITLE
Add PhaseCorrelationUDF for better sub-pixel accuracy

### DIFF
--- a/docs/source/changelog/features/phasexcorr.rst
+++ b/docs/source/changelog/features/phasexcorr.rst
@@ -1,0 +1,7 @@
+[Feature] PhaseCorrelationUDF
+=============================
+
+* Added :class:`libertem_blobfinder.udf.correlation.PhaseCorrelationUDF`.
+  Sub-pixel refinement using `skimage.registration.phase_cross_correlation`
+  which provides better estimates when shift values are very small.
+  (:issue:`39`, :pr:`39`)

--- a/docs/source/changelog/features/phasexcorr.rst
+++ b/docs/source/changelog/features/phasexcorr.rst
@@ -4,4 +4,4 @@
 * Added :class:`libertem_blobfinder.udf.correlation.PhaseCorrelationUDF`.
   Sub-pixel refinement using `skimage.registration.phase_cross_correlation`
   which provides better estimates when shift values are very small.
-  (:issue:`39`, :pr:`39`)
+  (:issue:`39`, :pr:`40`)

--- a/packaging/creators.json
+++ b/packaging/creators.json
@@ -16,6 +16,14 @@
         "orcid": "0000-0001-6635-9567"
     },
     {
+        "displayname": "Matthew Bryan",
+        "authorname": "Bryan, Matthew",
+        "affiliation": "CEA-Leti",
+        "github": "matbryan52",
+        "orcid": "0000-0001-9134-384X",
+        "contribution": "PhaseCorrelationUDF, bugfixes"
+    },    
+    {
         "displayname": "Karina Ruzaeva",
         "authorname": "Ruzaeva, Karina",
         "affiliation": "Jülich Research Centre" ,

--- a/src/libertem_blobfinder/base/correlation.py
+++ b/src/libertem_blobfinder/base/correlation.py
@@ -471,7 +471,7 @@ def process_frame_phase(template_fft, crop_size, frame, peaks,
                 normalization=normalization,
                 fft=fft,
             )
-                
+
             refined = shifts + peaks[idx]
             out_refineds[idx] = refined
             out_centers[idx] = np.round(refined).astype(int)

--- a/src/libertem_blobfinder/base/phase_xcorr.py
+++ b/src/libertem_blobfinder/base/phase_xcorr.py
@@ -1,0 +1,321 @@
+import numpy as np
+
+
+# Adapted from https://github.com/scikit-image/scikit-image/blob/v0.22.0/
+# ... skimage/registration/_phase_cross_correlation.py#L184-L396
+
+# Licensed under BSD-3-Clause
+"""
+BSD 3-Clause License
+
+Copyright (c) 2018, the respective contributors, as shown by the AUTHORS file.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+
+def _upsampled_dft(data, upsampled_region_size,
+                   upsample_factor=1, axis_offsets=None,
+                   fft=None):
+    """
+    Upsampled DFT by matrix multiplication.
+
+    This code is intended to provide the same result as if the following
+    operations were performed:
+        - Embed the array "data" in an array that is ``upsample_factor`` times
+          larger in each dimension.  ifftshift to bring the center of the
+          image to (1,1).
+        - Take the FFT of the larger array.
+        - Extract an ``[upsampled_region_size]`` region of the result, starting
+          with the ``[axis_offsets+1]`` element.
+
+    It achieves this result by computing the DFT in the output array without
+    the need to zeropad. Much faster and memory efficient than the zero-padded
+    FFT approach if ``upsampled_region_size`` is much smaller than
+    ``data.size * upsample_factor``.
+
+    Parameters
+    ----------
+    data : array
+        The input data array (DFT of original data) to upsample.
+    upsampled_region_size : integer or tuple of integers, optional
+        The size of the region to be sampled.  If one integer is provided, it
+        is duplicated up to the dimensionality of ``data``.
+    upsample_factor : integer, optional
+        The upsampling factor.  Defaults to 1.
+    axis_offsets : tuple of integers, optional
+        The offsets of the region to be sampled.  Defaults to None (uses
+        image center)
+
+    Returns
+    -------
+    output : ndarray
+            The upsampled DFT of the specified region.
+    """
+    if fft is None:
+        from scipy import fft
+
+    # if people pass in an integer, expand it to a list of equal-sized sections
+    if not hasattr(upsampled_region_size, "__iter__"):
+        upsampled_region_size = [upsampled_region_size, ] * data.ndim
+    else:
+        if len(upsampled_region_size) != data.ndim:
+            raise ValueError("shape of upsampled region sizes must be equal "
+                             "to input data's number of dimensions.")
+
+    if axis_offsets is None:
+        axis_offsets = [0, ] * data.ndim
+    else:
+        if len(axis_offsets) != data.ndim:
+            raise ValueError("number of axis offsets must be equal to input "
+                             "data's number of dimensions.")
+
+    im2pi = 1j * 2 * np.pi
+
+    dim_properties = list(zip(data.shape, upsampled_region_size, axis_offsets))
+
+    for (n_items, ups_size, ax_offset) in dim_properties[::-1]:
+        kernel = ((np.arange(ups_size) - ax_offset)[:, None]
+                  * fft.fftfreq(n_items, upsample_factor))
+        kernel = np.exp(-im2pi * kernel)
+        # use kernel with same precision as the data
+        kernel = kernel.astype(data.dtype, copy=False)
+
+        # Equivalent to:
+        #   data[i, j, k] = kernel[i, :] @ data[j, k].T
+        data = np.tensordot(kernel, data, axes=(1, -1))
+    return data
+
+
+def phase_cross_correlation(reference_image, moving_image, *,
+                            upsample_factor=1, space="real",
+                            normalization="phase", fft=None):
+    """Efficient subpixel image translation registration by cross-correlation.
+
+    This code gives the same precision as the FFT upsampled cross-correlation
+    in a fraction of the computation time and with reduced memory requirements.
+    It obtains an initial estimate of the cross-correlation peak by an FFT and
+    then refines the shift estimation by upsampling the DFT only in a small
+    neighborhood of that estimate by means of a matrix-multiply DFT [1]_.
+
+    Parameters
+    ----------
+    reference_image : array
+        Reference image.
+    moving_image : array
+        Image to register. Must be same dimensionality as
+        ``reference_image``.
+    upsample_factor : int, optional
+        Upsampling factor. Images will be registered to within
+        ``1 / upsample_factor`` of a pixel. For example
+        ``upsample_factor == 20`` means the images will be registered
+        within 1/20th of a pixel. Default is 1 (no upsampling).
+        Not used if any of ``reference_mask`` or ``moving_mask`` is not None.
+    space : string, one of "real" or "fourier", optional
+        Defines how the algorithm interprets input data. "real" means
+        data will be FFT'd to compute the correlation, while "fourier"
+        data will bypass FFT of input data. Case insensitive. Not
+        used if any of ``reference_mask`` or ``moving_mask`` is not
+        None.
+    disambiguate : bool
+        The shift returned by this function is only accurate *modulo* the
+        image shape, due to the periodic nature of the Fourier transform. If
+        this parameter is set to ``True``, the *real* space cross-correlation
+        is computed for each possible shift, and the shift with the highest
+        cross-correlation within the overlapping area is returned.
+    reference_mask : ndarray
+        Boolean mask for ``reference_image``. The mask should evaluate
+        to ``True`` (or 1) on valid pixels. ``reference_mask`` should
+        have the same shape as ``reference_image``.
+    moving_mask : ndarray or None, optional
+        Boolean mask for ``moving_image``. The mask should evaluate to ``True``
+        (or 1) on valid pixels. ``moving_mask`` should have the same shape
+        as ``moving_image``. If ``None``, ``reference_mask`` will be used.
+    overlap_ratio : float, optional
+        Minimum allowed overlap ratio between images. The correlation for
+        translations corresponding with an overlap ratio lower than this
+        threshold will be ignored. A lower `overlap_ratio` leads to smaller
+        maximum translation, while a higher `overlap_ratio` leads to greater
+        robustness against spurious matches due to small overlap between
+        masked images. Used only if one of ``reference_mask`` or
+        ``moving_mask`` is not None.
+    normalization : {"phase", None}
+        The type of normalization to apply to the cross-correlation. This
+        parameter is unused when masks (`reference_mask` and `moving_mask`) are
+        supplied.
+
+    Returns
+    -------
+    shift : ndarray
+        Shift vector (in pixels) required to register ``moving_image``
+        with ``reference_image``. Axis ordering is consistent with
+        the axis order of the input array.
+    error : float
+        Translation invariant normalized RMS error between
+        ``reference_image`` and ``moving_image``. For masked cross-correlation
+        this error is not available and NaN is returned.
+    phasediff : float
+        Global phase difference between the two images (should be
+        zero if images are non-negative). For masked cross-correlation
+        this phase difference is not available and NaN is returned.
+
+    Notes
+    -----
+    The use of cross-correlation to estimate image translation has a long
+    history dating back to at least [2]_. The "phase correlation"
+    method (selected by ``normalization="phase"``) was first proposed in [3]_.
+    Publications [1]_ and [2]_ use an unnormalized cross-correlation
+    (``normalization=None``). Which form of normalization is better is
+    application-dependent. For example, the phase correlation method works
+    well in registering images under different illumination, but is not very
+    robust to noise. In a high noise scenario, the unnormalized method may be
+    preferable.
+
+    When masks are provided, a masked normalized cross-correlation algorithm is
+    used [5]_, [6]_.
+
+    References
+    ----------
+    .. [1] Manuel Guizar-Sicairos, Samuel T. Thurman, and James R. Fienup,
+           "Efficient subpixel image registration algorithms,"
+           Optics Letters 33, 156-158 (2008). :DOI:`10.1364/OL.33.000156`
+    .. [2] P. Anuta, Spatial registration of multispectral and multitemporal
+           digital imagery using fast Fourier transform techniques, IEEE Trans.
+           Geosci. Electron., vol. 8, no. 4, pp. 353–368, Oct. 1970.
+           :DOI:`10.1109/TGE.1970.271435`.
+    .. [3] C. D. Kuglin D. C. Hines. The phase correlation image alignment
+           method, Proceeding of IEEE International Conference on Cybernetics
+           and Society, pp. 163-165, New York, NY, USA, 1975, pp. 163–165.
+    .. [4] James R. Fienup, "Invariant error metrics for image reconstruction"
+           Optics Letters 36, 8352-8357 (1997). :DOI:`10.1364/AO.36.008352`
+    .. [5] Dirk Padfield. Masked Object Registration in the Fourier Domain.
+           IEEE Transactions on Image Processing, vol. 21(5),
+           pp. 2706-2718 (2012). :DOI:`10.1109/TIP.2011.2181402`
+    .. [6] D. Padfield. "Masked FFT registration". In Proc. Computer Vision and
+           Pattern Recognition, pp. 2918-2925 (2010).
+           :DOI:`10.1109/CVPR.2010.5540032`
+    """
+
+    if fft is None:
+        from scipy import fft
+    
+    # Unpack fft functions
+    fftn = fft.fftn
+    ifftn = fft.ifftn
+
+    # images must be the same shape
+    if reference_image.shape != moving_image.shape:
+        raise ValueError("images must be same shape")
+
+    # assume complex data is already in Fourier space
+    if space.lower() == 'fourier':
+        src_freq = reference_image
+        target_freq = moving_image
+    # real data needs to be fft'd.
+    elif space.lower() == 'real':
+        src_freq = fftn(reference_image)
+        target_freq = fftn(moving_image)
+    else:
+        raise ValueError('space argument must be "real" of "fourier"')
+
+    # Whole-pixel shift - Compute cross-correlation by an IFFT
+    shape = src_freq.shape
+    image_product = src_freq * target_freq.conj()
+    if normalization == "phase":
+        eps = np.finfo(image_product.real.dtype).eps
+        image_product /= np.maximum(np.abs(image_product), 100 * eps)
+    elif normalization is not None:
+        raise ValueError("normalization must be either phase or None")
+    cross_correlation = ifftn(image_product)
+
+    # Locate maximum
+    maxima = np.unravel_index(np.argmax(np.abs(cross_correlation)),
+                              cross_correlation.shape)
+    midpoint = np.array([np.fix(axis_size / 2) for axis_size in shape])
+
+    float_dtype = image_product.real.dtype
+
+    shift = np.stack(maxima).astype(float_dtype, copy=False)
+    shift[shift > midpoint] -= np.array(shape)[shift > midpoint]
+
+    if upsample_factor == 1:
+        src_amp = np.sum(np.real(src_freq * src_freq.conj()))
+        src_amp /= src_freq.size
+        target_amp = np.sum(np.real(target_freq * target_freq.conj()))
+        target_amp /= target_freq.size
+        CCmax = cross_correlation[maxima]
+    # If upsampling > 1, then refine estimate with matrix multiply DFT
+    else:
+        # Initial shift estimate in upsampled grid
+        upsample_factor = np.array(upsample_factor, dtype=float_dtype)
+        shift = np.round(shift * upsample_factor) / upsample_factor
+        upsampled_region_size = np.ceil(upsample_factor * 1.5)
+        # Center of output array at dftshift + 1
+        dftshift = np.fix(upsampled_region_size / 2.0)
+        # Matrix multiply DFT around the current shift estimate
+        sample_region_offset = dftshift - shift*upsample_factor
+        cross_correlation_us = _upsampled_dft(image_product.conj(),
+                                              upsampled_region_size,
+                                              upsample_factor=upsample_factor,
+                                              axis_offsets=sample_region_offset,
+                                              fft=fft).conj()
+        # Locate maximum and map back to original pixel grid
+        maxima = np.unravel_index(np.argmax(np.abs(cross_correlation_us)),
+                                  cross_correlation_us.shape)
+        CCmax = cross_correlation_us[maxima]
+
+        maxima = np.stack(maxima).astype(float_dtype, copy=False)
+        maxima -= dftshift
+
+        shift += maxima / upsample_factor
+
+        src_amp = np.sum(np.real(src_freq * src_freq.conj()))
+        target_amp = np.sum(np.real(target_freq * target_freq.conj()))
+
+    # If its only one row or column the shift along that dimension has no
+    # effect. We set to zero.
+    for dim in range(src_freq.ndim):
+        if shape[dim] == 1:
+            shift[dim] = 0
+
+    # if disambiguate:
+    #     if space.lower() != 'real':
+    #         reference_image = ifftn(reference_image)
+    #         moving_image = ifftn(moving_image)
+    #     shift = _disambiguate_shift(reference_image, moving_image, shift)
+
+    # Redirect user to masked_phase_cross_correlation if NaNs are observed
+    if np.isnan(CCmax) or np.isnan(src_amp) or np.isnan(target_amp):
+        raise ValueError(
+            "NaN values found, please remove NaNs from your "
+            "input data or use the `reference_mask`/`moving_mask` "
+            "keywords, eg: "
+            "phase_cross_correlation(reference_image, moving_image, "
+            "reference_mask=~np.isnan(reference_image), "
+            "moving_mask=~np.isnan(moving_image))")
+
+    return shift, cross_correlation, CCmax

--- a/src/libertem_blobfinder/base/phase_xcorr.py
+++ b/src/libertem_blobfinder/base/phase_xcorr.py
@@ -222,7 +222,7 @@ def phase_cross_correlation(reference_image, moving_image, *,
 
     if fft is None:
         from scipy import fft
-    
+
     # Unpack fft functions
     fftn = fft.fftn
     ifftn = fft.ifftn

--- a/tests/test_udf.py
+++ b/tests/test_udf.py
@@ -255,6 +255,7 @@ def test_run_refine_fullframe(lt_ctx):
     [
         udf.correlation.FastCorrelationUDF,
         udf.correlation.FullFrameCorrelationUDF,
+        udf.correlation.PhaseCorrelationUDF,
     ]
 )
 def test_run_refine_blocktests(lt_ctx, cls):
@@ -308,6 +309,9 @@ def test_run_refine_blocktests(lt_ctx, cls):
         (udf.correlation.FastCorrelationUDF, int, {}),
         (udf.correlation.FastCorrelationUDF, float, {}),
         (udf.correlation.FastCorrelationUDF, float, {'zero_shift': (2, 3)}),
+        (udf.correlation.PhaseCorrelationUDF, int, {}),
+        (udf.correlation.PhaseCorrelationUDF, float, {}),
+        (udf.correlation.PhaseCorrelationUDF, float, {'zero_shift': (2, 3)}),
         (udf.correlation.SparseCorrelationUDF, int, {'steps': 3}),
         (udf.correlation.SparseCorrelationUDF, float, {'steps': 3}),
         (udf.correlation.SparseCorrelationUDF, float, {'steps': 3, 'zero_shift': (2, 7)}),


### PR DESCRIPTION
In response to #39 , adds a correlation UDF based on `skimage.registration.phase_cross_correlation` (https://scikit-image.org/docs/stable/api/skimage.registration.html#phase-cross-correlation)

This is a WIP as I don't yet have access to the correlation scores for calculating `peak_height` and `peak_elevation`. However I added the class to the `test_udf.py` test cases and it passes the existing tests where appropriate.

The current implementation is very similar to `FastCorrelationUDF`, i.e. crop from the frame then `fft2` each crop before giving these to `phase_cross_correlation` one-by-one.

We have to decide whether to use the `skimage` implementation or port / customise it for our use. Notably porting would allow us to:

- Implement `FullFrameCorrelationUDF`-like behaviour (one fft for the whole frame then crop)
- Get access to the correlation scores to correctly fill `height` and `elevations`
- Potentially numba-accelerate some parts of the code
- Ensure we use the same fft backend for all of the computations (currently inside their `phase_cross_correlation`)

I haven't done any benchmarking but I imagine this will be a lot slower in some cases than the current implementation because we don't have that numba acceleration. For only a few peaks it's not noticeable because I pre-fft the inputs to the function anyway.

## To-Do:

* [ ] Decide whether to port the implementation
* [ ] Add an option `correlation='phase'` to `run_refinement` etc.
* [ ] Add test cases specific to very small shifts (the current test cases don't catch this apparently)

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM-blobfinder/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM-blobfinder/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
