### PR TITLE
DFT upsampling-based refinement

### DIFF
--- a/docs/source/changelog/features/upsampling.rst
+++ b/docs/source/changelog/features/upsampling.rst
@@ -5,4 +5,4 @@
   can give more precise results when peak shifts are sub-pixel
   at the expense of increased computation, and is available
   using the :code:`upsample=True` argument to UDF and associated
-  functions (see :issue:`39`). (:pr:`70`).
+  functions (see :issue:`39`, :pr:`70`).

--- a/docs/source/changelog/features/upsampling.rst
+++ b/docs/source/changelog/features/upsampling.rst
@@ -1,0 +1,8 @@
+[Feature] Upsampling DFT for peak position refinement
+=====================================================
+* Fourier upsampling is now implemented for calculating the
+  'refineds' peak positions in correlation UDFs. This approach
+  can give more precise results when peak shifts are sub-pixel
+  at the expense of increased computation, and is available
+  using the :code:`upsample=True` argument to UDF and associated
+  functions (see :issue:`39`). (:pr:`70`).

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -7,5 +7,3 @@ sphinx-rtd-theme
 nbsphinx!=0.8.8
 nbsphinx_link
 ipython
-# temporary for https://github.com/jupyter/nbconvert/issues/2092
-nbconvert<7.14

--- a/examples/strainmap-SiGe.ipynb
+++ b/examples/strainmap-SiGe.ipynb
@@ -538,7 +538,6 @@
     "        indices=np.mgrid[-3:4, -3:4],\n",
     "        matcher=matcher,\n",
     "        match_pattern=custom_pattern,\n",
-    "        progress=True\n",
     "    )"
    ]
   },

--- a/packaging/creators.json
+++ b/packaging/creators.json
@@ -24,6 +24,14 @@
         "orcid": "0000-0003-3610-0989"
     },
     {
+        "displayname": "Matthew Bryan",
+        "authorname": "Bryan, Matthew",
+        "affiliation": "CEA-Leti",
+        "github": "matbryan52",
+        "contribution": "Upsampling DFT refinement",
+        "orcid": "0000-0001-9134-384X"
+    },    
+    {
         "displayname": "Knut Müller-Caspary",
         "authorname": "Müller-Caspary, Knut",
         "affiliation": "Jülich Research Centre",

--- a/src/libertem_blobfinder/base/correlation.py
+++ b/src/libertem_blobfinder/base/correlation.py
@@ -369,6 +369,9 @@ def process_frame_fast(template, crop_size, frame, peaks,
         Aligned buffer for pyfftw. Shape (n, 2 * crop_size, 2 * crop_size) and float dtype.
         n doesn't have to match the number of peaks. Instead, it should be chosen for good L3 cache
         efficiency. :meth:`allocate_crop_bufs` can be used to allocate this buffer.
+    upsample : Union[Literal[False], int]
+        Whether to use upsampling DFT for refinement. False to deactivate (default) or a positive
+        integer >1 to upsample by this factor when refining the correlation peak positions.
 
     Returns
     -------
@@ -473,6 +476,9 @@ def process_frame_full(template, crop_size, frame, peaks,
     buf_count : int
         Number of peaks to process per outer loop iteration. This allows optimization of L3 cache
         efficiency.
+    upsample : Union[Literal[False], int]
+        Whether to use upsampling DFT for refinement. False to deactivate (default) or a positive
+        integer >1 to upsample by this factor when refining the correlation peak positions.
 
 
     Returns

--- a/src/libertem_blobfinder/base/correlation.py
+++ b/src/libertem_blobfinder/base/correlation.py
@@ -213,7 +213,7 @@ def do_correlations(template, crop_parts):
     '''
     spec_parts = fft.rfft2(crop_parts)
     corrspecs = template * spec_parts
-    corrs = fft.fftshift(
+    corrs = fft.ifftshift(
         fft.irfft2(
             corrspecs,
             s=crop_parts.shape[-2:],

--- a/src/libertem_blobfinder/base/correlation.py
+++ b/src/libertem_blobfinder/base/correlation.py
@@ -213,7 +213,13 @@ def do_correlations(template, crop_parts):
     '''
     spec_parts = fft.rfft2(crop_parts)
     corrspecs = template * spec_parts
-    corrs = fft.fftshift(fft.irfft2(corrspecs), axes=(-1, -2))
+    corrs = fft.fftshift(
+        fft.irfft2(
+            corrspecs,
+            s=crop_parts.shape[-2:],
+        ),
+        axes=(-2, -1),
+    )
     return corrs, corrspecs
 
 

--- a/src/libertem_blobfinder/base/correlation.py
+++ b/src/libertem_blobfinder/base/correlation.py
@@ -36,7 +36,11 @@ def _upsampled_dft(
     upsampled_region_size: int,
     axis_offsets: Tuple[float, float],
 ) -> np.ndarray:
-
+    """
+    Heavily adapted from skimage.registration._phase_cross_correlation.py
+    which is itself based on code by Manuel Guizar released initially under a
+    BSD 3-Clause license @ https://www.mathworks.com/matlabcentral/fileexchange/18401
+    """
     im2pi = -1j * 2 * np.pi
     upsampled = corrspecs
     for (ax_freq, ax_offset) in zip(frequencies[::-1], axis_offsets[::-1]):
@@ -80,6 +84,8 @@ def refine_center_upsampling(
     refined : np.ndarray[(2,), np.float32]
         The position of the refined maximum
     '''
+    # Same license info as in the function _upsampled_dft
+
     # Move the real position in corr to the position
     # in the fft (essentially apply fftshift without wrapping)
     shift = upsample_pos - corrmap_center

--- a/src/libertem_blobfinder/base/correlation.py
+++ b/src/libertem_blobfinder/base/correlation.py
@@ -567,8 +567,14 @@ def process_frame_full(template, crop_size, frame, peaks,
     log_scale(frame, out=frame_buf)
     spec_part = fft.rfft2(frame_buf)
     corrspec = template * spec_part
-    corr = fft.fftshift(fft.irfft2(corrspec))
-    crop_bufs = np.zeros((buf_count, 2 * crop_size, 2 * crop_size), dtype=corr.dtype)
+    corr = fft.ifftshift(
+        fft.irfft2(
+            corrspec, s=frame_buf.shape[-2:],
+        ),
+        axes=(-2, -1),
+    )
+    crop_shape = (2 * crop_size, 2 * crop_size)
+    crop_bufs = np.zeros((buf_count, *crop_shape), dtype=corr.dtype)
     block_count = (len(peaks) - 1) // buf_count + 1
     for block in range(block_count):
         start = block * buf_count

--- a/src/libertem_blobfinder/base/correlation.py
+++ b/src/libertem_blobfinder/base/correlation.py
@@ -260,7 +260,7 @@ def evaluate_upsampling(corrspecs, corrs, peaks, crop_size, sig_shape, upsample_
     # evaluate_upsampling_fast and evaluate_upsampling_full
     corrspec_stack = corrspecs.ndim == 3
     corr_shape = corrs.shape[1:] if corrspec_stack else sig_shape
-    corr_center = np.asarray(corr_shape) / 2
+    corr_center = np.ceil(np.asarray(corr_shape) / 2, dtype=np.float32)
 
     frequencies = (
         fft.fftfreq(corr_shape[0], upsample_factor),

--- a/src/libertem_blobfinder/base/correlation.py
+++ b/src/libertem_blobfinder/base/correlation.py
@@ -40,6 +40,8 @@ def _upsampled_dft(
     Heavily adapted from skimage.registration._phase_cross_correlation.py
     which is itself based on code by Manuel Guizar released initially under a
     BSD 3-Clause license @ https://www.mathworks.com/matlabcentral/fileexchange/18401
+
+    :meta private:
     """
     im2pi = -1j * 2 * np.pi
     upsampled = corrspecs
@@ -83,6 +85,8 @@ def refine_center_upsampling(
     -------
     refined : np.ndarray[(2,), np.float32]
         The position of the refined maximum
+
+    :meta private:
     '''
     # Same license info as in the function _upsampled_dft
 
@@ -261,6 +265,46 @@ def evaluate_correlations(corrs, peaks, crop_size,
 
 def evaluate_upsampling(corrspecs, corrs, peaks, crop_size, sig_shape, upsample_factor,
         out_centers, out_refineds):
+    """
+    Evaluate the refined peak positions using DFT upsampling
+
+    Internally re-inverts corrspecs with upsampling around
+    the positions found in out_centers, and places the
+    argmax of these new corrmaps into out_refineds.
+
+    This function operates either on a full-frame corrspecs (ndim of 2)
+    or a stack of corrspecs (ndim of 3) when using the 'fast' processing
+    mode (crops of the frame).
+
+    Parameters
+    ----------
+    corrspecs : numpy.ndarray
+        The rFFT correlations before inversion. If :code:`ndim == 3`
+        we are processing a stack of crops from a frame, while if
+        :code:`ndim == 2` we are processing the correlation map of
+        the whole frame.
+    corrs : numpy.ndarray
+        Stack of correlation maps, either matching the stack of corrspecs
+        (fast processing), or crops from the full-frame correlation map.
+    peaks : np.ndarray
+        List of peaks of shape (n_peaks, 2) in full-frame frame coordinates,
+        matching the order of corrs if processing crops.
+    crop_size : int
+        Half the size of the correlation pattern used to compute corrspecs.
+    sig_shape : Tuple[int, int]
+        The shape of the full frame
+    upsample_factor : int
+        The degree to upsample the frame, determines the precision
+        of the result (:code:`1 / upsample_factor`).
+    out_centers : np.ndarray
+        Buffer filled with for unrefined peak positions of shape (n_peaks, 2).
+        These are read to know the upsampling location.
+    out_refineds : np.ndarray
+        Output buffer for refined center positions of shape (n_peaks, 2)
+        and float dtype, values will be overwritten with the upsampled coordinates.
+
+    :meta private:
+    """
     # A corrspec stack means we are processing corrspecs of crops of the frame
     # and corrs are the irfft2 of each corrspec. Otherwise, corrspecs is the single rfft2
     # of the whole frame and corrs are the crops from the irfft2 of corrspecs.

--- a/src/libertem_blobfinder/base/correlation.py
+++ b/src/libertem_blobfinder/base/correlation.py
@@ -470,7 +470,7 @@ def process_frame_fast(template, crop_size, frame, peaks,
     upsample : Union[bool, int], optional
         Whether to use upsampling DFT for refinement. False to deactivate (default) or a positive
         integer >1 to upsample by this factor when refining the correlation peak positions. Upsample
-        True will choose a sensible upmsapling factor.
+        True will choose a sensible upsampling factor.
 
     Returns
     -------
@@ -579,7 +579,7 @@ def process_frame_full(template, crop_size, frame, peaks,
     upsample : Union[bool, int], optional
         Whether to use upsampling DFT for refinement. False to deactivate (default) or a positive
         integer >1 to upsample by this factor when refining the correlation peak positions. Upsample
-        True will choose a sensible upmsapling factor.
+        True will choose a sensible upsampling factor.
 
 
     Returns

--- a/src/libertem_blobfinder/base/correlation.py
+++ b/src/libertem_blobfinder/base/correlation.py
@@ -393,8 +393,9 @@ def process_frame_fast(template, crop_size, frame, peaks,
     ----------
     template : numpy.ndarray
         Real Fourier transform of the correlation pattern.
-        The source pattern should have size (2 * crop_size, 2 * crop_size). Please note that
-        the real Fourier transform (fft.rfft2) of the source pattern has a different shape!
+        The source pattern shape should match the shape[1:] of crop_bufs.
+        Please note that the real Fourier transform (fft.rfft2) of the
+        source pattern has a different shape!
     crop_size : int
         Half the size of the correlation pattern. Given as a parameter since real Fourier
         transform changes the size.
@@ -495,7 +496,8 @@ def process_frame_full(template, crop_size, frame, peaks,
     ----------
     template : numpy.ndarray
         Real Fourier transform of the correlation pattern.
-        The source pattern should have size (2 * crop_size, 2 * crop_size). Please note that
+        The source pattern shape should match the argument crop_size, either the supplied
+        shape or (2 * crop_size, 2 * crop_size) if default. Please note that
         the real Fourier transform (fft.rfft2) of the source pattern has a different shape!
     crop_size : int
         Half the size of the correlation pattern. Given as a parameter since real Fourier

--- a/src/libertem_blobfinder/common/correlation.py
+++ b/src/libertem_blobfinder/common/correlation.py
@@ -91,6 +91,12 @@ def process_frames_fast(
         Frame data. Currently, only Real values are supported.
     peaks : np.ndarray
         List of peaks of shape (n_peaks, 2)
+    upsample: Union[bool, int]
+        Use DFT upsampling for the refinement step, by default False. Supplying
+        True will choose a reasonable default upsampling factor, while any
+        positive integer > 1 will upsample the correlation peak by this factor.
+        DFT upsampling can provide more accurate center values, especially when
+        peak shifts are small, but does require more computation time.
 
     Returns
     -------
@@ -162,6 +168,12 @@ def process_frames_full(
         Frame data. Currently, only real values are supported.
     peaks : np.ndarray
         List of peaks of shape (n_peaks, 2)
+    upsample: Union[bool, int]
+        Use DFT upsampling for the refinement step, by default False. Supplying
+        True will choose a reasonable default upsampling factor, while any
+        positive integer > 1 will upsample the correlation peak by this factor.
+        DFT upsampling can provide more accurate center values, especially when
+        peak shifts are small, but does require more computation time.
 
     Returns
     -------

--- a/src/libertem_blobfinder/common/correlation.py
+++ b/src/libertem_blobfinder/common/correlation.py
@@ -67,7 +67,7 @@ def get_peaks(sum_result, match_pattern: MatchPattern, num_peaks):
     return peaks
 
 
-def process_frames_fast(pattern: MatchPattern, frames, peaks):
+def process_frames_fast(pattern: MatchPattern, frames, peaks, upsample=False):
     '''
     Find the parameters of peaks in a diffraction pattern by correlation with a match pattern.
 
@@ -126,12 +126,12 @@ def process_frames_fast(pattern: MatchPattern, frames, peaks):
             frame=f, peaks=peaks.astype(np.int32),
             out_centers=centers[i], out_refineds=refineds[i],
             out_heights=heights[i], out_elevations=elevations[i],
-            crop_bufs=crop_bufs
+            crop_bufs=crop_bufs, upsample=upsample,
         )
     return (centers, refineds, heights, elevations)
 
 
-def process_frames_full(pattern: MatchPattern, frames, peaks):
+def process_frames_full(pattern: MatchPattern, frames, peaks, upsample=False):
     '''
     Find the parameters of peaks in a diffraction pattern by correlation with a match pattern.
 
@@ -193,6 +193,6 @@ def process_frames_full(pattern: MatchPattern, frames, peaks):
             frame=f, peaks=peaks.astype(np.int32),
             out_centers=centers[i], out_refineds=refineds[i],
             out_heights=heights[i], out_elevations=elevations[i],
-            frame_buf=frame_buf, buf_count=buf_count
+            frame_buf=frame_buf, buf_count=buf_count, upsample=upsample,
         )
     return (centers, refineds, heights, elevations)

--- a/src/libertem_blobfinder/common/correlation.py
+++ b/src/libertem_blobfinder/common/correlation.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import numpy as np
 from skimage.feature import peak_local_max
 
@@ -67,7 +69,10 @@ def get_peaks(sum_result, match_pattern: MatchPattern, num_peaks):
     return peaks
 
 
-def process_frames_fast(pattern: MatchPattern, frames, peaks, upsample=False):
+def process_frames_fast(
+    pattern: MatchPattern, frames, peaks,
+    upsample: Union[bool, int] = False
+):
     '''
     Find the parameters of peaks in a diffraction pattern by correlation with a match pattern.
 
@@ -110,6 +115,9 @@ def process_frames_fast(pattern: MatchPattern, frames, peaks, upsample=False):
     ... )
     >>> assert np.allclose(refineds[0], peaks, atol=0.1)
     '''
+    if upsample is True:
+        upsample = 20
+
     crop_size = pattern.get_crop_size()
     template = pattern.get_template(sig_shape=(2 * crop_size, 2 * crop_size))
 
@@ -131,7 +139,10 @@ def process_frames_fast(pattern: MatchPattern, frames, peaks, upsample=False):
     return (centers, refineds, heights, elevations)
 
 
-def process_frames_full(pattern: MatchPattern, frames, peaks, upsample=False):
+def process_frames_full(
+    pattern: MatchPattern, frames, peaks,
+    upsample: Union[bool, int] = False
+):
     '''
     Find the parameters of peaks in a diffraction pattern by correlation with a match pattern.
 
@@ -175,6 +186,9 @@ def process_frames_full(pattern: MatchPattern, frames, peaks, upsample=False):
     ... )
     >>> assert np.allclose(refineds[0], peaks, atol=0.1)
     '''
+    if upsample is True:
+        upsample = 20
+
     crop_size = pattern.get_crop_size()
     template = pattern.get_template(sig_shape=frames[0].shape)
 

--- a/src/libertem_blobfinder/common/correlation.py
+++ b/src/libertem_blobfinder/common/correlation.py
@@ -125,7 +125,7 @@ def process_frames_fast(
     crop_size = pattern.get_crop_size()
     template = pattern.get_template(sig_shape=(2 * crop_size, 2 * crop_size))
 
-    centers = np.zeros((len(frames), len(peaks), 2), dtype=np.uint16)
+    centers = np.zeros((len(frames), len(peaks), 2), dtype=np.int16)
     refineds = np.zeros((len(frames), len(peaks), 2), dtype=np.float32)
     heights = np.zeros((len(frames), len(peaks)), dtype=np.float32)
     elevations = np.zeros((len(frames), len(peaks)), dtype=np.float32)

--- a/src/libertem_blobfinder/common/correlation.py
+++ b/src/libertem_blobfinder/common/correlation.py
@@ -91,7 +91,7 @@ def process_frames_fast(
         Frame data. Currently, only Real values are supported.
     peaks : np.ndarray
         List of peaks of shape (n_peaks, 2)
-    upsample: Union[bool, int]
+    upsample: Union[bool, int], optional
         Use DFT upsampling for the refinement step, by default False. Supplying
         True will choose a reasonable default upsampling factor, while any
         positive integer > 1 will upsample the correlation peak by this factor.
@@ -121,8 +121,6 @@ def process_frames_fast(
     ... )
     >>> assert np.allclose(refineds[0], peaks, atol=0.1)
     '''
-    if upsample is True:
-        upsample = 20
 
     crop_size = pattern.get_crop_size()
     template = pattern.get_template(sig_shape=(2 * crop_size, 2 * crop_size))
@@ -168,7 +166,7 @@ def process_frames_full(
         Frame data. Currently, only real values are supported.
     peaks : np.ndarray
         List of peaks of shape (n_peaks, 2)
-    upsample: Union[bool, int]
+    upsample: Union[bool, int], optional
         Use DFT upsampling for the refinement step, by default False. Supplying
         True will choose a reasonable default upsampling factor, while any
         positive integer > 1 will upsample the correlation peak by this factor.
@@ -198,9 +196,6 @@ def process_frames_full(
     ... )
     >>> assert np.allclose(refineds[0], peaks, atol=0.1)
     '''
-    if upsample is True:
-        upsample = 20
-
     crop_size = pattern.get_crop_size()
     template = pattern.get_template(sig_shape=frames[0].shape)
 

--- a/src/libertem_blobfinder/common/patterns.py
+++ b/src/libertem_blobfinder/common/patterns.py
@@ -183,10 +183,10 @@ class UserTemplate(MatchPattern):
                 continue
             before = after = extra // 2
             if (before + after) != extra:
-                # In practice sig_shape is always even (2 * crop_size)
+                # In the default case sig_shape is always even (2 * crop_size)
                 # so this path implies the template has an odd dimension.
                 # therefore a choice here of how to centre the array
-                # left += 1
+                # before += 1
                 after += 1
             result = fn(
                 result,

--- a/src/libertem_blobfinder/udf/correlation.py
+++ b/src/libertem_blobfinder/udf/correlation.py
@@ -47,7 +47,7 @@ class CorrelationUDF(UDF):
 
         return {
             'centers': self.buffer(
-                kind="nav", extra_shape=(num_disks, 2), dtype="u2"
+                kind="nav", extra_shape=(num_disks, 2), dtype=np.int32,
             ),
             'refineds': self.buffer(
                 kind="nav", extra_shape=(num_disks, 2), dtype="float32"

--- a/src/libertem_blobfinder/udf/correlation.py
+++ b/src/libertem_blobfinder/udf/correlation.py
@@ -33,7 +33,9 @@ class CorrelationUDF(UDF):
         The common buffers for all correlation methods.
 
         :code:`centers`:
-            (y, x) integer positions.
+            (y, x) integer positions. NOTE: the returned positions
+            can be out-of-frame and the user should perform bounds
+            checking if directly indexing into the frame array.
         :code:`refineds`:
             (y, x) positions with subpixel refinement.
         :code:`peak_values`:

--- a/src/libertem_blobfinder/udf/correlation.py
+++ b/src/libertem_blobfinder/udf/correlation.py
@@ -364,7 +364,7 @@ def run_fastcorrelation(
     upsample : Union[bool, int], optional
         Whether to use upsampling DFT for refinement. False to deactivate (default) or a positive
         integer >1 to upsample by this factor when refining the correlation peak positions. Upsample
-        True will choose a sensible upmsapling factor.
+        True will choose a sensible upsampling factor.
     kwargs : passed through to :meth:`~libertem.api.Context.run_udf`
 
     Returns

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -113,8 +113,8 @@ def test_com():
     "sig_shape", (
         (64, 64),
         (61, 67),
-        (31, 32),
-        (32, 31),
+        (57, 60),
+        (63, 72),
     )
 )
 @pytest.mark.parametrize(
@@ -152,13 +152,6 @@ def test_refinement_upsampling(upsample_factor, sig_shape, shift):
         corr.argmax(),
         corr.shape,
     )
-
-    # This "correction" is for testing and should be
-    # integrated into the implementation
-    correction = np.asarray(tuple(s % 2 for s in sig_shape))
-    peak_argmax += correction
-    # coarse_max = (np.round(shift) + np.asarray(sig_shape) // 2)
-    # assert coarse_max == approx(peak_argmax)
 
     corr_shape = corr.shape
     corr_centre = np.ceil(np.asarray(corr_shape) / 2, dtype=np.float32)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -144,6 +144,7 @@ def test_refinement_upsampling(upsample_factor, sig_shape, shift):
     corrs, corrspecs = do_correlations(
         template[np.newaxis, ...],
         frame_shifted[np.newaxis, ...],
+        with_specs=True,
     )
     corr = corrs[0]
     corrspec = corrspecs[0]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -110,16 +110,21 @@ def test_com():
     "upsample_factor", (10, 25)
 )
 @pytest.mark.parametrize(
+    "sig_shape", (
+        (64, 64),
+        (61, 67),
+    )
+)
+@pytest.mark.parametrize(
     "shift", (
         (-3.7, 4.2),
         (6.7, 8.1),
         (0.2, 9.7),
     )
 )
-def test_refinement_upsampling(upsample_factor, shift):
+def test_refinement_upsampling(upsample_factor, sig_shape, shift):
     fft = libertem_blobfinder.base.correlation.fft
 
-    sig_shape = (64, 64)
     radius = 13
 
     pattern = Circular(radius)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,9 +1,7 @@
 import functools
 
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
-from scipy.signal import correlate2d
 
 import libertem.masks as m
 from libertem.utils.generate import cbed_frame
@@ -11,10 +9,6 @@ from libertem.io.dataset.memory import MemoryDataSet
 from libertem.udf.masks import ApplyMasksUDF
 
 from libertem_blobfinder import common
-import libertem_blobfinder.common.correlation
-from libertem_blobfinder.common.correlation import process_frames_fast
-import libertem_blobfinder.common.patterns
-from libertem_blobfinder.common.patterns import UserTemplate
 import libertem_blobfinder.udf.refinement  # noqa F401
 
 
@@ -205,29 +199,3 @@ def test_standalone_full():
         print(peaks - refineds)
 
         assert np.allclose(refineds[0], peaks, atol=0.5)
-
-
-@pytest.mark.parametrize(
-        'where', ((0, 0), (2, 3)),
-)
-@pytest.mark.parametrize(
-        'peak', ((1, 1), (3, 2)),
-)
-def test_scipy_correlate2d(where, peak):
-    frame = np.zeros((5, 6))
-    frame[where] = 1
-    pattern = frame.copy()
-    correlated = correlate2d(frame, pattern, mode='same')
-    ref_center = np.unravel_index(
-        np.argmax(correlated),
-        frame.shape
-    )
-    centers, refineds, heights, elevations = process_frames_fast(
-        pattern=UserTemplate(pattern),
-        frames=np.array([frame]),
-        peaks=np.array([peak]),
-        upsample=False
-    )
-    print(frame)
-    print(ref_center, centers[0, 0])
-    assert_allclose(ref_center, centers[0, 0])

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -211,9 +211,9 @@ def test_standalone_full():
         'where', ((0, 0), (2, 3)),
 )
 @pytest.mark.parametrize(
-        'expected', ((1, 1), (3, 2)),
+        'peak', ((1, 1), (3, 2)),
 )
-def test_scipy_correlate2d(where, expected):
+def test_scipy_correlate2d(where, peak):
     frame = np.zeros((5, 6))
     frame[where] = 1
     pattern = frame.copy()
@@ -225,7 +225,7 @@ def test_scipy_correlate2d(where, expected):
     centers, refineds, heights, elevations = process_frames_fast(
         pattern=UserTemplate(pattern),
         frames=np.array([frame]),
-        peaks=np.array([expected]),
+        peaks=np.array([peak]),
         upsample=False
     )
     print(frame)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,7 +1,9 @@
 import functools
 
 import numpy as np
+from numpy.testing import assert_allclose
 import pytest
+from scipy.signal import correlate2d
 
 import libertem.masks as m
 from libertem.utils.generate import cbed_frame
@@ -10,7 +12,9 @@ from libertem.udf.masks import ApplyMasksUDF
 
 from libertem_blobfinder import common
 import libertem_blobfinder.common.correlation
+from libertem_blobfinder.common.correlation import process_frames_fast
 import libertem_blobfinder.common.patterns
+from libertem_blobfinder.common.patterns import UserTemplate
 import libertem_blobfinder.udf.refinement  # noqa F401
 
 
@@ -201,3 +205,29 @@ def test_standalone_full():
         print(peaks - refineds)
 
         assert np.allclose(refineds[0], peaks, atol=0.5)
+
+
+@pytest.mark.parametrize(
+        'where', ((0, 0), (2, 3)),
+)
+@pytest.mark.parametrize(
+        'expected', ((1, 1), (3, 2)),
+)
+def test_scipy_correlate2d(where, expected):
+    frame = np.zeros((5, 6))
+    frame[where] = 1
+    pattern = frame.copy()
+    correlated = correlate2d(frame, pattern, mode='same')
+    ref_center = np.unravel_index(
+        np.argmax(correlated),
+        frame.shape
+    )
+    centers, refineds, heights, elevations = process_frames_fast(
+        pattern=UserTemplate(pattern),
+        frames=np.array([frame]),
+        peaks=np.array([expected]),
+        upsample=False
+    )
+    print(frame)
+    print(ref_center, centers[0, 0])
+    assert_allclose(ref_center, centers[0, 0])

--- a/tests/test_udf.py
+++ b/tests/test_udf.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 import matplotlib.pyplot as plt
 
 import libertem_blobfinder.common.gridmatching as grm
@@ -370,8 +371,10 @@ def test_correlation_methods(lt_ctx, cls, dtype, kwargs):
             # for p in np.flip(res['refineds'].data[0], axis=-1):
             #     ax.add_artist(plt.Circle(p, radius, fill=False, color='y'))
             # plt.show()
-
-            assert np.allclose(res['refineds'].data[0], peaks, atol=0.5)
+            atol = 0.5
+            if 'upsample' in kwargs:
+                atol = 0.25
+            assert_allclose(res['refineds'].data[0], peaks, atol=atol)
 
 
 @pytest.mark.with_numba
@@ -431,7 +434,10 @@ def test_correlation_method_fullframe(lt_ctx, cls, dtype, kwargs):
         # for p in np.flip(res['refineds'].data[0], axis=-1):
         #     ax.add_artist(plt.Circle(p, radius, fill=False, color='y'))
         # plt.show()
-        assert np.allclose(res['refineds'].data[0], peaks, atol=0.5)
+        atol = 0.5
+        if 'upsample' in kwargs:
+            atol = 0.25
+        assert_allclose(res['refineds'].data[0], peaks, atol=atol)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_udf.py
+++ b/tests/test_udf.py
@@ -308,6 +308,8 @@ def test_run_refine_blocktests(lt_ctx, cls):
         (udf.correlation.FastCorrelationUDF, int, {}),
         (udf.correlation.FastCorrelationUDF, float, {}),
         (udf.correlation.FastCorrelationUDF, float, {'zero_shift': (2, 3)}),
+        (udf.correlation.FastCorrelationUDF, int, {'upsample': True}),
+        (udf.correlation.FastCorrelationUDF, int, {'upsample': 15}),
         (udf.correlation.SparseCorrelationUDF, int, {'steps': 3}),
         (udf.correlation.SparseCorrelationUDF, float, {'steps': 3}),
         (udf.correlation.SparseCorrelationUDF, float, {'steps': 3, 'zero_shift': (2, 7)}),
@@ -378,6 +380,7 @@ def test_correlation_methods(lt_ctx, cls, dtype, kwargs):
     [
         (udf.correlation.FullFrameCorrelationUDF, int, {}),
         (udf.correlation.FullFrameCorrelationUDF, float, {}),
+        (udf.correlation.FullFrameCorrelationUDF, int, {'upsample': True}),
     ]
 )
 def test_correlation_method_fullframe(lt_ctx, cls, dtype, kwargs):
@@ -428,7 +431,6 @@ def test_correlation_method_fullframe(lt_ctx, cls, dtype, kwargs):
         # for p in np.flip(res['refineds'].data[0], axis=-1):
         #     ax.add_artist(plt.Circle(p, radius, fill=False, color='y'))
         # plt.show()
-
         assert np.allclose(res['refineds'].data[0], peaks, atol=0.5)
 
 

--- a/tests/test_udf.py
+++ b/tests/test_udf.py
@@ -372,8 +372,9 @@ def test_correlation_methods(lt_ctx, cls, dtype, kwargs):
             #     ax.add_artist(plt.Circle(p, radius, fill=False, color='y'))
             # plt.show()
             atol = 0.5
-            if 'upsample' in kwargs:
-                atol = 0.25
+            # Because of rounding in cbed_frame, cannot be sure of tolerance!
+            # if 'upsample' in kwargs:
+            #     atol = 0.25
             assert_allclose(res['refineds'].data[0], peaks, atol=atol)
 
 
@@ -435,8 +436,9 @@ def test_correlation_method_fullframe(lt_ctx, cls, dtype, kwargs):
         #     ax.add_artist(plt.Circle(p, radius, fill=False, color='y'))
         # plt.show()
         atol = 0.5
-        if 'upsample' in kwargs:
-            atol = 0.25
+        # Because of rounding in cbed_frame, cannot be sure of tolerance!
+        # if 'upsample' in kwargs:
+        #     atol = 0.25
         assert_allclose(res['refineds'].data[0], peaks, atol=atol)
 
 


### PR DESCRIPTION
Closes #39 and #40. I realised that what we wanted out of the Phase XCorrelation implementation was the upsampling, not actually the phase normalisation (though this might be useful on some data!).

Ports a modified form of scikit-image's `_upsampled_dft` to fix the error in our CoM-based refinement step. Accessed via an `upsample: Union[bool, int]` param on Fast/Full Correlation UDFs and in the backend functions. Default behavior is `False` i.e. no upsampling, `True` chooses an 20x upsample factor (0.05 px precision), int values set the factor.

This increases computation time as it essentially is a custom `irfft2` called for each peak, for full-frame correlation this means we are inverting the whole `corrspecs` once for each peak in the frame! Right at the bottom there are two calls to `np.tensordot`, once per axis. I think it might be possible to get broadcasting to work so that all the peaks could be upsampled in one operation, but I haven't looked closely yet. In the fast correlation case the arrays are quite small so it shouldn't be too bad.

* [x] ~~I've noticed that the tests fail with something like an off-by-one if I supply them with uneven-sized frames to upsample. This could be the PR code itself or some other off-by-one error in the test or its supporting functions. To investigate...~~ Partially fixed here and the rest will fix in another PR (see #72).
* [x] I don't quite know how to license / attribute this - the original code is BSD-3 here (https://www.mathworks.com/matlabcentral/fileexchange/18401), then scikit-image ported it (also BSD-3)
* [x] Add acknowledgements for ported code
* [ ] ~~Extend this to `SparseCorrelationUDF` if possible / interesting. Not simple as this doesn't use FFT but rather direct correlation.~~ Not feasible!

Result from an example notebook :

![image](https://github.com/LiberTEM/LiberTEM-blobfinder/assets/78845903/eaa04c6f-0dc8-4298-93ec-f2b5ef461252)

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM-blobfinder/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM-blobfinder/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases