### PR TITLE
Update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "numpy",
     "numba>=0.49",
     "sparseconverter",
+    "scipy",
+    "sparse",
     "scikit-image",
 ]
 keywords = ["electron microscopy"]


### PR DESCRIPTION
We do directly import `scipy` and `sparse`, so we should also depend on them. This currently works anyways, because both are transitive dependencies of `sparseconverter`.

## Contributor Checklist:

* [ ] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM-blobfinder/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM-blobfinder/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
