### PR TITLE
Add True => 20 in process_frame_fast

### DIFF
--- a/src/libertem_blobfinder/base/correlation.py
+++ b/src/libertem_blobfinder/base/correlation.py
@@ -533,6 +533,8 @@ def process_frame_fast(
     ...     )
     >>> assert np.allclose(refineds[0], peaks, atol=0.1)
     '''
+    if upsample is True:
+        upsample = 20
     buf_count = len(crop_bufs)
     block_count = (len(peaks) - 1) // buf_count + 1
     for block in range(block_count):


### PR DESCRIPTION
Fixes missing default parameter conversion when using `upsample = True` and `FastCorrelation`.

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM-blobfinder/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM-blobfinder/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases